### PR TITLE
feature/uni-125-proposal-display-issues

### DIFF
--- a/hooks/governance/useAllProposalData.js
+++ b/hooks/governance/useAllProposalData.js
@@ -124,7 +124,7 @@ const getAllProposalData = (
 };
 
 export default function useAllProposalData() {
-  const { library } = useWeb3React();
+  const { library, chainId } = useWeb3React();
 
   const govContract = useGovernanceContract();
 
@@ -147,6 +147,7 @@ export default function useAllProposalData() {
           // putting `proposalIndexes.length` and `formattedEvents.length` in cache key
           // so that refetch is triggered when their length changes
           `AllProposalData-${proposalIndexes.length}-${formattedEvents.length}`,
+          chainId,
         ]
       : null,
     getAllProposalData(govContract, library, proposalIndexes, formattedEvents),

--- a/hooks/governance/useAllProposalData.js
+++ b/hooks/governance/useAllProposalData.js
@@ -124,7 +124,7 @@ const getAllProposalData = (
 };
 
 export default function useAllProposalData() {
-  const { library, chainId } = useWeb3React();
+  const { library } = useWeb3React();
 
   const govContract = useGovernanceContract();
 
@@ -138,8 +138,17 @@ export default function useAllProposalData() {
   // get metadata from past events
   const { data: formattedEvents } = useDataFromEventLogs();
 
+  const shouldFetch =
+    govContract && library && proposalCount && formattedEvents;
+
   return useSWR(
-    ["AllProposalData", chainId],
+    shouldFetch
+      ? [
+          // putting `proposalIndexes.length` and `formattedEvents.length` in cache key
+          // so that refetch is triggered when their length changes
+          `AllProposalData-${proposalIndexes.length}-${formattedEvents.length}`,
+        ]
+      : null,
     getAllProposalData(govContract, library, proposalIndexes, formattedEvents),
     {
       shouldRetryOnError: false,

--- a/styles/index.css
+++ b/styles/index.css
@@ -569,3 +569,21 @@ input[type="number"] {
     rgba(252, 247, 247, 0) 100%
   );
 }
+
+.markdown-ol {
+  list-style: decimal;
+  margin-left: 1rem;
+}
+
+.markdown-ul {
+  list-style: disc;
+  margin-left: 1rem;
+}
+
+.markdown-li {
+  margin-bottom: 0.5rem;
+}
+
+.markdown-p {
+  margin-bottom: 1rem;
+}

--- a/views/governance/proposal.js
+++ b/views/governance/proposal.js
@@ -157,7 +157,23 @@ export default function ProposalView() {
                   {data?.description ? (
                     <ReactMarkdown
                       renderers={{
-                        link: (props) => <a className="underline" {...props} />,
+                        /* eslint-disable no-unused-vars */
+                        link: ({ node, ...props }) => (
+                          <a className="underline" {...props} />
+                        ),
+                        list: ({ ordered, node, ...props }) =>
+                          ordered ? (
+                            <ol className="markdown-ol" {...props} />
+                          ) : (
+                            <ul className="markdown-ul" {...props} />
+                          ),
+                        paragraph: ({ node, ...props }) => (
+                          <p className="markdown-p" {...props} />
+                        ),
+                        listItem: ({ node, ...props }) => (
+                          <li className="markdown-li" {...props} />
+                        ),
+                        /* eslint-enable no-unused-vars */
                       }}
                     >
                       {data?.description}


### PR DESCRIPTION
- Puts `proposalIndexes.length` and `formattedEvents.length` in cache key while fetching proposals to trigger refetch
- Adds classes and styles for markdown of proposal description
