### PR TITLE
feature/uni 232 transfer stat shows as on when transfer

### DIFF
--- a/constants/abis/unionToken.json
+++ b/constants/abis/unionToken.json
@@ -126,6 +126,44 @@
     "type": "event"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      }
+    ],
+    "name": "Unwhitelisted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "WhitelistDisabled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "WhitelistEnabled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      }
+    ],
+    "name": "Whitelisted",
+    "type": "event"
+  },
+  {
     "constant": true,
     "inputs": [],
     "name": "DELEGATION_TYPEHASH",
@@ -198,21 +236,6 @@
     "outputs": [],
     "payable": false,
     "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "constant": true,
-    "inputs": [],
-    "name": "allowTransfer",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "payable": false,
-    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -357,21 +380,6 @@
   {
     "constant": true,
     "inputs": [],
-    "name": "comptroller",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "constant": true,
-    "inputs": [],
     "name": "decimals",
     "outputs": [
       {
@@ -484,6 +492,24 @@
     ],
     "payable": false,
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "disableWhitelist",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "enableWhitelist",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -639,6 +665,27 @@
       }
     ],
     "name": "isAdmin",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      }
+    ],
+    "name": "isWhitelisted",
     "outputs": [
       {
         "internalType": "bool",
@@ -876,41 +923,11 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_comptroller",
-        "type": "address"
-      }
-    ],
-    "name": "setComptroller",
-    "outputs": [],
-    "payable": false,
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "constant": false,
-    "inputs": [
-      {
-        "internalType": "address",
         "name": "account",
         "type": "address"
       }
     ],
     "name": "setGuardian",
-    "outputs": [],
-    "payable": false,
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "constant": false,
-    "inputs": [
-      {
-        "internalType": "bool",
-        "name": "_allowTransfer",
-        "type": "bool"
-      }
-    ],
-    "name": "setTransferability",
     "outputs": [],
     "payable": false,
     "stateMutability": "nonpayable",
@@ -1010,6 +1027,51 @@
     "outputs": [],
     "payable": false,
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      }
+    ],
+    "name": "unwhitelist",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      }
+    ],
+    "name": "whitelist",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "whitelistEnabled",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
     "type": "function"
   }
 ]

--- a/hooks/stats/unionTokenStats/useUnionPausedState.ts
+++ b/hooks/stats/unionTokenStats/useUnionPausedState.ts
@@ -3,7 +3,7 @@ import useUnionContract from "hooks/contracts/useUnionContract";
 import useSWR from "swr";
 
 const getUnionPausedState = (unionContract: Contract) => async (_: any) => {
-  return unionContract.paused();
+  return unionContract.whitelistEnabled();
 };
 
 export default function useUnionPausedState() {

--- a/views/stats/UnionToken.js
+++ b/views/stats/UnionToken.js
@@ -71,7 +71,13 @@ export default function UnionTokenStatsView() {
             />
             <StatsCard
               label="Transfers"
-              value={isUnionTransferPaused ? "Off" : "On"}
+              value={
+                isUnionTransferPaused === undefined
+                  ? "NaN"
+                  : isUnionTransferPaused
+                  ? "Off"
+                  : "On"
+              }
             />
           </StatsGrid>
         </div>


### PR DESCRIPTION
We changed to use whitelist based pause sometime back and UI had to been updated for this change.
This change along with the fact that undefined == false in js caused UI to show transfers on. 
We didnt notice this till now because previous testnets had transfers on.