### PR TITLE
fix: Fixed plug-in "react-ridge-state" version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react-hook-form": "^6.11.3",
     "react-jazzicon-custom-colors": "^0.1.7",
     "react-markdown": "^5.0.2",
-    "react-ridge-state": "^4.1.6",
+    "react-ridge-state": "4.1.6",
     "react-table": "^7.6.2",
     "react-use": "^15.3.4",
     "swr": "^0.3.9",


### PR DESCRIPTION
Fixed version 4.1.6, because the latest version will cause "Cannot use import statement outside a module" error